### PR TITLE
fixed init_backend

### DIFF
--- a/backend/database/fetch_feast_users.py
+++ b/backend/database/fetch_feast_users.py
@@ -21,17 +21,19 @@ def generate_password(length=10) -> str:
 async def seed_users():
     users = feast_service.get_all_existing_users()
 
-    async for db in get_db():  # Correct usage
+    async for db in get_db():
         for row in users:
-            user_id = int(row["user_id"])
-            if len(str(user_id)) == 27:  # skip new users
+            user_id = str(row["user_id"])  # Treat user_id as string
+
+            # Skip new users: 27-digit numeric strings only
+            if user_id.isdigit() and len(user_id) == 27:
                 continue
 
             result = await db.execute(select(User).where(User.user_id == user_id))
             if result.scalar_one_or_none():
                 continue
 
-            email = generate_email(str(user_id))
+            email = generate_email(user_id)
             password = generate_password()
 
             print(f"Seeding user: {user_id}, email: {email}")

--- a/backend/init_backend.py
+++ b/backend/init_backend.py
@@ -18,7 +18,7 @@ async def create_tables():
 
 async def setup_all():
     await create_tables()
-    # await seed_users()
+    await seed_users()
 
 if __name__ == "__main__":
     asyncio.run(setup_all())

--- a/backend/models.py
+++ b/backend/models.py
@@ -25,7 +25,7 @@ class Product(BaseModel):
     description: str
 
 class User(BaseModel):
-    user_id: int
+    user_id: str  
     email: str
     age: int
     gender: str
@@ -34,7 +34,7 @@ class User(BaseModel):
     views: Optional[List[Product]] = None
 
 class Feedback(BaseModel):
-    userId: int
+    userId: str  
     productId: int
     rating: float
     title: Optional[str] = ''
@@ -55,25 +55,24 @@ class AuthResponse(BaseModel):
     token: str
 
 class CartItem(BaseModel):
-    user_id: int
+    user_id: str  
     product_id: int
     quantity: int
 
 class CheckoutRequest(BaseModel):
-    user_id: int
+    user_id: str  
     items: List[CartItem]
     shipping_address: str
     payment_method: str
 
 class Order(BaseModel):
     order_id: int
-    user_id: int
+    user_id: str  
     items: List[CartItem]
     total_amount: float
     order_date: datetime
     status: str
 
 class WishlistItem(BaseModel):
-    user_id: int
+    user_id: str  
     product_id: int
-

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -40,7 +40,7 @@ async def get_current_user(
         sub = payload.get("sub")
         if sub is None:
             raise credentials_exception
-        user_id = int(sub)
+        user_id = str(sub)
     except (JWTError, ValueError):
         raise credentials_exception
     result = await db.execute(select(User).where(User.user_id == user_id))

--- a/backend/routes/cart.py
+++ b/backend/routes/cart.py
@@ -6,7 +6,7 @@ from services.kafka_service import kafka_service
 router = APIRouter()
 
 @router.get("/cart/{user_id}", response_model=List[CartItem])
-def get_cart(user_id: int):
+def get_cart(user_id: str):
     return []
 
 @router.post("/cart", status_code=204)

--- a/backend/routes/orders.py
+++ b/backend/routes/orders.py
@@ -21,5 +21,5 @@ def checkout(request: CheckoutRequest):
     )
 
 @router.get("/orders/{user_id}", response_model=List[Order])
-def get_order_history(user_id: int):
+def get_order_history(user_id: str):
     return []

--- a/backend/routes/products.py
+++ b/backend/routes/products.py
@@ -23,7 +23,7 @@ async def search_products_by_image(image):
     return []
 
 @router.get("/products/{product_id}", response_model=Product)
-async def get_product(product_id: int, user_id: int = 1):
+async def get_product(product_id: int, user_id: str = 1):
     """
     Get product details by ID
     """
@@ -38,7 +38,7 @@ async def get_product(product_id: int, user_id: int = 1):
     raise HTTPException(status_code=501, detail="Not implemented")
 
 @router.post("/products/{product_id}/interactions/click", status_code=204)
-async def record_product_click(product_id: int, user_id: int):
+async def record_product_click(product_id: int, user_id: str):
     """
     Records a product click interaction event
     """

--- a/backend/routes/recommendations.py
+++ b/backend/routes/recommendations.py
@@ -12,7 +12,7 @@ router = APIRouter()
 
 # GET for existing users
 @router.get("/recommendations/{user_id}", response_model=List[Product])
-def get_recommendations(user_id: int):
+def get_recommendations(user_id: str):
     try:
         return feast_service.load_items_existing_user(user_id)
     except Exception as e:

--- a/backend/routes/wishlist.py
+++ b/backend/routes/wishlist.py
@@ -5,7 +5,7 @@ from models import WishlistItem, Product
 router = APIRouter()
 
 @router.get("/wishlist/{user_id}", response_model=List[Product])
-def get_wishlist(user_id: int):
+def get_wishlist(user_id: str):
     return []
 
 @router.post("/wishlist", status_code=204)

--- a/backend/services/feast_service.py
+++ b/backend/services/feast_service.py
@@ -14,7 +14,7 @@ import pandas as pd
 
 class FeastService:
     _instance = None
-    
+
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(FeastService, cls).__new__(cls)
@@ -33,66 +33,55 @@ class FeastService:
         from sqlalchemy import text
         from sqlalchemy import create_engine
 
-        # Create database connection
         database_url = os.getenv('DATABASE_URL')
         engine = create_engine(database_url)
-        
+
         with engine.connect() as connection:
-            # Query the latest version
             result = connection.execute(text("SELECT version FROM model_version ORDER BY updated_at DESC LIMIT 1"))
             version = result.fetchone()[0]
             return version
 
-
     def _load_user_encoder(self):
         minio_client = Minio(
-            endpoint=os.getenv('MINIO_HOST', "endpoint") + \
-                ':' + os.getenv('MINIO_PORT', '9000'),
+            endpoint=os.getenv('MINIO_HOST', "endpoint") + ':' + os.getenv('MINIO_PORT', '9000'),
             access_key=os.getenv('MINIO_ACCESS_KEY', "access-key"),
             secret_key=os.getenv('MINIO_SECRET_KEY', "secret-key"),
-            secure=False  # Set to True if using HTTPS
+            secure=False
         )
         model_version = self._load_model_version()
         bucket_name = "user-encoder"
         object_name = f"user-encoder-{model_version}.pth"
         configuration = f'user-encoder-config-{model_version}.json'
-        
-        # Download the model file from MinIO
+
         minio_client.fget_object(bucket_name, object_name, "/tmp/user-encoder.pth")
         minio_client.fget_object(bucket_name, configuration, "/tmp/user-encoder-config.json")
-        # Load the model state dict using torch.load
+
         with open('/tmp/user-encoder-config.json', 'r') as f:
             json_config = json.load(f)
         user_encoder = EntityTower(json_config['users_num_numerical'], json_config['users_num_categorical'])
         user_encoder.load_state_dict(torch.load('/tmp/user-encoder.pth'))
-        # Clean up the temporary folder
-        
+
         return user_encoder
-    
+
     def get_all_existing_users(self) -> List[dict]:
         try:
             user_df = self.dataset_provider.user_df()
             print("Fetched all users")
             return user_df.to_dict(orient="records")
-
         except Exception as e:
             print(f"Failed to fetch users from feature view: {e}")
             return []
-    
-    def load_items_existing_user(self, user_id: int) -> List[Product]:
+
+    def load_items_existing_user(self, user_id: str) -> List[Product]:
         suggested_item_ids = self.store.get_online_features(
             features=self.store.get_feature_service('user_top_k_items'),
             entity_rows=[{'user_id': user_id}]
         )
-        
         top_item_ids = suggested_item_ids.to_df().iloc[0]['top_k_item_ids']
-        
         return self._item_ids_to_product_list(top_item_ids)
-
 
     def load_items_new_user(self, user: User, k: int = 10):
         user_as_df = pd.DataFrame([user.model_dump()])
-        
         user_embed = self.user_encoder(**data_preproccess(user_as_df))[0]
         top_k = self.store.retrieve_online_documents(
             query=user_embed.tolist(),
@@ -100,24 +89,20 @@ class FeastService:
             features=['item_embedding:item_id']
         )
         top_item_ids = top_k.to_df().iloc[0]['top_k_item_ids']
-
         return self._item_ids_to_product_list(top_item_ids)
-    
+
     def _item_ids_to_product_list(self, top_item_ids: pd.Series | List) -> List[Product]:
-    
         suggested_item = self.store.get_online_features(
             features=self.store.get_feature_service('item_service'),
-            entity_rows=[{'item_id': item_id}  for item_id in top_item_ids]
+            entity_rows=[{'item_id': item_id} for item_id in top_item_ids]
         ).to_df()
-        
         print(suggested_item.columns)
         print(suggested_item)
-        # Parse df to list of products
         suggested_item = [Product(
             item_id=row.item_id,
             name=row.name,
             category=row.category,
-            subcategory=row.subcategory, 
+            subcategory=row.subcategory,
             price=row.price,
             avg_rating=row.avg_rating,
             num_ratings=row.num_ratings,
@@ -128,6 +113,6 @@ class FeastService:
             description=row.description
         ) for row in suggested_item.itertuples()]
         return suggested_item
-# Initilaize the service
-feast_service = FeastService()
 
+# Initialize the service
+feast_service = FeastService()

--- a/backend/services/kafka_service.py
+++ b/backend/services/kafka_service.py
@@ -27,7 +27,7 @@ class KafkaService:
             "type": "struct",
             "fields": [{
                 "field": "user_id",
-                "type": "string",  # ✅ Changed from int32 to string
+                "type": "string", 
                 "optional": False,
             }, {
                 "field": "item_id",
@@ -100,7 +100,7 @@ class KafkaService:
         """Send an interaction event to Kafka"""
         schema = self._build_interaction_schema()
         interaction = {
-            'user_id': str(user_id),  # ✅ Explicit cast to string
+            'user_id': str(user_id),  
             'item_id': item_id,
             'timestamp': datetime.now().isoformat(" "),
             'interaction_type': interaction_type,

--- a/backend/services/kafka_service.py
+++ b/backend/services/kafka_service.py
@@ -6,13 +6,13 @@ from typing import Optional, Dict, Any, Union
 
 class KafkaService:
     _instance = None
-    
+
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(KafkaService, cls).__new__(cls)
             cls._instance._initialize()
         return cls._instance
-    
+
     def _initialize(self):
         """Initialize the Kafka producer"""
         kafka_service = os.getenv("KAFKA_SERVICE_ADDR", 'rec-sys-cluster-kafka-bootstrap.rec-sys.svc.cluster.local:9092')
@@ -20,14 +20,14 @@ class KafkaService:
             bootstrap_servers=kafka_service,
             value_serializer=lambda v: json.dumps(v).encode('utf-8')
         )
-    
+
     def _build_interaction_schema(self) -> Dict[str, Any]:
         """Build the schema for interaction messages"""
         return {
             "type": "struct",
             "fields": [{
                 "field": "user_id",
-                "type": "int32",
+                "type": "string",  # ✅ Changed from int32 to string
                 "optional": False,
             }, {
                 "field": "item_id",
@@ -66,7 +66,7 @@ class KafkaService:
             "optional": False,
             "name": "interaction"
         }
-    
+
     def _build_new_user_schema(self) -> Dict[str, Any]:
         """Build the schema for new user messages"""
         return {
@@ -92,22 +92,23 @@ class KafkaService:
             "optional": False,
             "name": "new-users"
         }
-    
-    def send_interaction(self, user_id: int, item_id: int, interaction_type: str, 
-                        rating: Optional[int] = None, quantity: Optional[int] = None,
-                        review_title: Optional[str] = None,
-                        review_content: Optional[str] = None) -> None:
+
+    def send_interaction(self, user_id: str, item_id: int, interaction_type: str,
+                         rating: Optional[int] = None, quantity: Optional[int] = None,
+                         review_title: Optional[str] = None,
+                         review_content: Optional[str] = None) -> None:
         """Send an interaction event to Kafka"""
         schema = self._build_interaction_schema()
         interaction = {
-            'user_id': user_id,
+            'user_id': str(user_id),  # ✅ Explicit cast to string
             'item_id': item_id,
             'timestamp': datetime.now().isoformat(" "),
             'interaction_type': interaction_type,
             'rating': int(rating) if rating is not None else None,
             'quantity': int(quantity) if quantity is not None else None,
             'review_title': review_title if review_title is not None else '',
-            'review_content': review_content if review_content is not None else ''
+            'review_content': review_content if review_content is not None else '',
+            'interaction_id': f"{user_id}-{item_id}-{datetime.utcnow().timestamp()}"  # example unique ID
         }
         message = {
             "schema": schema,
@@ -115,7 +116,7 @@ class KafkaService:
         }
         self.producer.send('interactions', message)
         self.producer.flush()
-    
+
     def send_new_user(self, user_id: Union[int, str], user_name: str, preferences: str) -> None:
         """Send a new user event to Kafka"""
         schema = self._build_new_user_schema()
@@ -132,5 +133,6 @@ class KafkaService:
         self.producer.send('new-users', message)
         self.producer.flush()
 
-# Initilaize the singleton
-kafka_service = KafkaService() 
+
+# Initialize the singleton
+kafka_service = KafkaService()

--- a/helm/product-recommender-system/values.yaml
+++ b/helm/product-recommender-system/values.yaml
@@ -165,8 +165,8 @@ affinity: {}
 pipelineJobImage: quay.io/ecosystem-appeng/rec-sys-workflow:0.0.6b
 frontendImage: quay.io/ecosystem-appeng/rec-sys-ui:0.0.4
 applicationImage: quay.io/ecosystem-appeng/rec-sys-app:0.0.44
-backendImage: quay.io/ikatav/rec-sys-backend:0.0.1b
 
+backendImage: quay.io/ikatav/rec-sys-backend:0.0.2
 dbName: product_recommender_system
 
 env:


### PR DESCRIPTION
This PR refactors the backend to treat user_id consistently as a string instead of an integer. This change supports alphanumeric user IDs returned from Feast (e.g., PBQ4Q5JE535HJB7JF0R79NHJS8) and aligns with the updated signup logic that generates 27-digit string IDs for new users.

Summary of Changes:
1. Updated user_id types from int → str across Pydantic models, SQLAlchemy schema, and route handlers.

2. Adjusted JWT handling, database queries, and Kafka message formats to use string IDs.

3. Updated the Kafka schema for interactions to store user_id as a string.

4. Seed logic (seed_users) now populates the users table using existing Feast users where applicable.

This sets the foundation for unified handling of users across both Feast and our backend system.