### PR TITLE
bugfix: change run name to be the date instead of constant name "1"

### DIFF
--- a/helm/product-recommender-system/templates/_helpers.tpl
+++ b/helm/product-recommender-system/templates/_helpers.tpl
@@ -116,7 +116,7 @@ spec:
       - name: EXPERIMENT_NAME
         value: 'Default'
       - name: RUN_NAME
-        value: '1'
+        value: '{{ now | date "2006_01_02_15_04_05" }}'
       - name: DS_PIPELINE_URL
         value: https://ds-pipeline-dspa.{{ .Release.Namespace }}.svc.cluster.local:8888
       - name: DB_SECRET_NAME


### PR DESCRIPTION
This solve the bug when the cron job is running with the same name of the last job then it fails